### PR TITLE
fix: keypress state tracking when the UI is shown again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.9.1
+          version: stable
 
       - name: generate documentation
         run: make documentation-ci
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        neovim_version: ['v0.7.2', 'v0.8.3', 'v0.9.1', 'nightly']
+        neovim_version: ['stable', 'nightly']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
           version: latest
           args: --check .
 
+      - uses: lunarmodules/luacheck@v1
+        with:
+          args: lua/ tests/ scripts/ plugin/
+
   documentation:
     runs-on: ubuntu-latest
     name: documentation

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,1 +1,22 @@
+std = "luajit"
+codes = true
+
+-- formatting is stylua's job
+max_line_length = false
+
+-- callbacks often receive arguments they don't use
+unused_args = false
+
 globals = { "vim" }
+
+exclude_files = {
+  "deps/",
+}
+
+files["tests/**/*.lua"] = {
+  read_globals = { "MiniTest" },
+}
+
+files["scripts/**/*.lua"] = {
+  read_globals = { "MiniDoc" },
+}

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ documentation-ci: deps documentation
 lint:
 	stylua .
 
+# performs a static analysis check, following the config in `.luacheckrc`.
+luacheck:
+	luacheck lua/ tests/ scripts/ plugin/
+
 # setup
 setup:
 	./scripts/setup.sh

--- a/doc/keyseer.txt
+++ b/doc/keyseer.txt
@@ -1,5 +1,3 @@
-==============================================================================
-------------------------------------------------------------------------------
 *KeySeer* See your keys and their keymaps
 
 ------------------------------------------------------------------------------
@@ -7,10 +5,10 @@
                            `KeySeer.setup`({config})
 Plugin setup
 
-Parameters~
+Parameters ~
 {config} `(table|nil)` Module config table. See |KeySeer.config|.
 
-Usage~
+Usage ~
 `require('keyseer').setup({})` (replace `{}` with your `config` table)
 
 ------------------------------------------------------------------------------
@@ -19,7 +17,7 @@ Usage~
 KeySeer Config
 
 Default values:
->
+>lua
   KeySeer.config = {
     -- Prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
@@ -93,14 +91,13 @@ Default values:
   -- KeySeer functionality ========================================
   --
 <
-
 ------------------------------------------------------------------------------
                                                                 *KeySeer.show()*
                         `KeySeer.show`({mode}, {bufnr})
 the keyseer ui
-Parameters~
+Parameters ~
 {mode} `(optional)` `(string)` the neovim mode to show keymaps for
-{bufnr} `(optional)` buffer the buffer for buffer specific keymaps
+{bufnr} `(optional)` `(buffer)` the buffer for buffer specific keymaps
 
 ------------------------------------------------------------------------------
                                                                *KeySeer.close()*

--- a/lua/keyseer/keyboard/init.lua
+++ b/lua/keyseer/keyboard/init.lua
@@ -30,37 +30,7 @@ local function get_line(opts)
   return _borders[table.concat(opts, "")]
 end
 
--- From https://hiphish.github.io/blog/2022/03/15/lua-metatables-for-neovim-plugin-settings/
-local function make_mt(default)
-  return {
-    __index = function(t, k)
-      local original = default[k]
-      if type(original) ~= "table" then
-        return original
-      end
-      rawset(t, k, {})
-      setmetatable(t[k], make_mt(original))
-    end,
-    __newindex = function(t, k, v)
-      rawset(t, k, v)
-      if type(v) ~= "table" then
-        return
-      end
-      setmetatable(v, make_mt(default[k]))
-    end,
-  }
-end
-
-local function default_table()
-  return setmetatable({}, {
-    -- ensure every entry in the table is a table
-    __index = function(tbl, key)
-      local new_tbl = {}
-      rawset(tbl, key, new_tbl)
-      return new_tbl
-    end,
-  })
-end
+local default_table = Utils.default_table
 
 ---@class Keyboard
 ---@field padding PaddingBox The spacing around each button keycap
@@ -229,17 +199,15 @@ function Keyboard:_layout_buttons(shift_pressed)
   --  ├────────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─────────┤
   --  │ <SHIFT>  │ z │ x │ c │ v │ b │ n │ m │ , │ . │ / │  <SHIFT>  │
   --  └──────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───────────┘
-  -- Reset button mapping tables
+  -- Reset the button mapping table that is about to be rebuilt so that
+  -- laying out the keyboard again does not accumulate duplicate buttons
   if shift_pressed then
-    self._normal_buttons = default_table()
-  else
     self._shifted_buttons = default_table()
+  else
+    self._normal_buttons = default_table()
   end
-  local button_lookup = self._normal_buttons
+  local button_lookup = shift_pressed and self._shifted_buttons or self._normal_buttons
   self._locations = button_lookup
-  if shift_pressed then
-    button_lookup = self._shifted_buttons
-  end
 
   self._rows = {}
   self._keycap_separator_colomns = {}

--- a/lua/keyseer/keymaps/init.lua
+++ b/lua/keyseer/keymaps/init.lua
@@ -8,6 +8,19 @@ local Utils = require("keyseer.utils")
 
 local if_nil = vim.F.if_nil
 
+---@alias KeySeerModifier "<Ctrl>"|"<Shift>"|"<Meta>"
+
+---Fill in missing modifier keys as not pressed
+---@param modifiers table<KeySeerModifier,boolean>|nil
+---@return table<KeySeerModifier,boolean>
+local function with_default_modifiers(modifiers)
+  return vim.tbl_deep_extend(
+    "force",
+    { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
+    modifiers or {}
+  )
+end
+
 -- The Keymaps class does the work of converting the neovim keymaps to keymap layers
 ---@class Keymaps
 ---@field root KeyMapTreeNode The root of the keymap treenode
@@ -143,49 +156,23 @@ function Keymaps:add_keymaps(keymaps)
   end
 end
 
+---Reduce a modifier table to its canonical form
+---Shift is dropped when Ctrl is held because a Ctrl chord cannot
+---distinguish shifted from unshifted keys (<C-a> and <C-A> are the same)
+---@param modifiers table<KeySeerModifier,boolean>
+---@return string
+local function canonical_modifiers(modifiers)
+  local shift = modifiers["<Shift>"] and not modifiers["<Ctrl>"]
+  return (modifiers["<Ctrl>"] and "C" or "")
+    .. (modifiers["<Meta>"] and "M" or "")
+    .. (shift and "S" or "")
+end
+
 ---Return a boolean for whether or not the modifiers match
----@param left table[string,boolean]
----@param right table[tring,boolean]
+---@param left table<KeySeerModifier,boolean>
+---@param right table<KeySeerModifier,boolean>
 local function modifiers_match(left, right)
-  -- only ctrl, shift, meta, ctrl+meta, meta+shift are valid modifiers
-  -- therefore if ctrl doesn't match or meta doesn't match then it can't match
-  if left["<Ctrl>"] then
-    if not right["<Ctrl>"] then
-      -- ctrl doesn't match, false
-      return false
-    elseif left["<Meta>"] == right["<Meta>"] then
-      -- meta and ctrl match, return true
-      return true
-    else
-      -- meta doesn't match, false
-      return false
-    end
-  elseif right["<Ctrl>"] then
-    -- ctrl doesn't match, false
-    return false
-  end
-  if left["<Meta>"] then
-    if not right["<Meta>"] then
-      -- meta doesn't match, false
-      return false
-    elseif left["<Shift>"] == right["<Shift>"] then
-      -- meta and shift match, return true
-      return true
-    else
-      -- shift doesn't match, false
-      return false
-    end
-  elseif right["<Meta>"] then
-    -- meta doesn't match, false
-    return false
-  end
-
-  if left["<Shift>"] == right["<Shift>"] then
-    -- shift matches, return true
-    return true
-  end
-
-  return false
+  return canonical_modifiers(left) == canonical_modifiers(right)
 end
 
 ---Return a boolean for whether or not the keypress matches the modifiers
@@ -193,29 +180,15 @@ end
 ---@param modifiers table<string,boolean>
 function Keymaps.matching_keypress(node, modifiers)
   vim.validate({ modifiers = { modifiers, "table", true } })
-  modifiers = vim.tbl_deep_extend(
-    "force",
-    { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
-    modifiers or {}
-  )
-  local node_modifiers = vim.tbl_deep_extend(
-    "force",
-    { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
-    node.modifiers
-  )
 
-  return modifiers_match(modifiers, node_modifiers)
+  return modifiers_match(with_default_modifiers(modifiers), with_default_modifiers(node.modifiers))
 end
 
 ---Get the keycaps at the current node
 ---@return table<KeyCapTreeNode>
 function Keymaps:get_current_keycaps(modifiers, opts)
   vim.validate({ modifiers = { modifiers, "table", true } })
-  modifiers = vim.tbl_deep_extend(
-    "force",
-    { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
-    modifiers or {}
-  )
+  modifiers = with_default_modifiers(modifiers)
   opts = vim.tbl_deep_extend(
     "force",
     { ["add_modifiers"] = false, ["match_modifiers"] = true },
@@ -227,14 +200,6 @@ function Keymaps:get_current_keycaps(modifiers, opts)
     if pressed then
       ret[modifier] = "KeySeerKeycapKeymap"
     end
-  end
-
-  if modifiers["<Ctrl>"] and modifiers["<Meta>"] then
-    Utils.notify(
-      "Ctrl and Meta cannot be used in the same keymap, please deselect a modifier.",
-      { level = vim.log.WARN }
-    )
-    return ret
   end
 
   local matching_keypresses = {}
@@ -341,19 +306,11 @@ end
 ---@param modifiers table<string,boolean> The modifier states
 function Keymaps:get_keymaps(keycode, modifiers)
   vim.validate({ modifiers = { modifiers, "table", true } })
-  modifiers = vim.tbl_deep_extend(
-    "force",
-    { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
-    modifiers or {}
-  )
+  modifiers = with_default_modifiers(modifiers)
 
   local ret = nil
   for _, node in pairs(self.current_node.children) do
-    local node_modifiers = vim.tbl_deep_extend(
-      "force",
-      { ["<Ctrl>"] = false, ["<Shift>"] = false, ["<Meta>"] = false },
-      node.modifiers
-    )
+    local node_modifiers = with_default_modifiers(node.modifiers)
 
     local matches = node.keycode == keycode
     if modifiers["<Ctrl>"] and not matches then

--- a/lua/keyseer/keymaps/init.lua
+++ b/lua/keyseer/keymaps/init.lua
@@ -38,6 +38,16 @@ end
 ---@returns table
 function Keymaps:process_keymaps(bufnr, mode)
   mode = mode or Config.initial_mode
+  -- Rebuild the tree from scratch so that processing keymaps again
+  -- (e.g. running :KeySeer while the UI is open) does not insert
+  -- duplicate keymaps or leave the current node in a stale tree
+  self.root = {
+    keymaps = {},
+    modifiers = {},
+    children = {},
+  }
+  self.stack = {}
+  self.current_node = self.root
   if Config.include_builtin_keymaps then
     local preset_keymaps = BuiltInKeyMaps[mode]
     self:add_keymaps(preset_keymaps)

--- a/lua/keyseer/ui/init.lua
+++ b/lua/keyseer/ui/init.lua
@@ -19,7 +19,8 @@ local Keymaps = require("keyseer.keymaps")
 ---@field modifiers table{string,boolean} What modifier buttons are considered pressed
 ---@field bufnr buffer|nil The buffer
 local default_state = {
-  pane = "home",
+  -- empty until set_pane enters the first pane
+  pane = "",
   prev_pane = "",
   mode = "n",
   current_keymaps = {},
@@ -59,6 +60,32 @@ local function get_button_under_cursor(ui)
   return button
 end
 
+---Run a lifecycle hook for a pane if the pane defines it
+---@param pane string The pane name
+---@param hook string The hook name ("on_enter" or "on_exit")
+---@param ui KeySeerUI The UI
+local function pane_hook(pane, hook, ui)
+  local pane_available, pane_module = pcall(require, "keyseer.ui.panes." .. pane)
+  if pane_available and pane_module and vim.is_callable(pane_module[hook]) then
+    pane_module[hook](ui)
+  end
+end
+
+---Change the active pane
+---This is the only place that writes state.pane and state.prev_pane so
+---that the pane lifecycle hooks run exactly once for every pane change,
+---no matter where the change comes from.
+---@param pane string The pane to show
+function KeySeerUI:set_pane(pane)
+  if pane == self.state.pane then
+    return
+  end
+  pane_hook(self.state.pane, "on_exit", self)
+  self.state.prev_pane = self.state.pane
+  self.state.pane = pane
+  pane_hook(pane, "on_enter", self)
+end
+
 ---Show the KeySeer UI
 ---@param pane? string The starting pane
 ---@param mode? string The neovim mode for keymaps
@@ -68,11 +95,16 @@ function KeySeerUI.show(pane, mode, bufnr)
   KeySeerUI.ui = KeySeerUI.visible() and KeySeerUI.ui or KeySeerUI.create(bufnr)
 
   KeySeerUI.ui.state.mode = mode or KeySeerUI.ui.state.mode
-  KeySeerUI.ui.state.pane = pane or KeySeerUI.ui.state.pane
-
   KeySeerUI.ui.state.bufnr = bufnr
 
   KeySeerUI.ui.state.keymaps:process_keymaps(bufnr, KeySeerUI.ui.state.mode)
+
+  -- keep the current pane unless a pane was requested or no pane is shown yet
+  local target = pane or KeySeerUI.ui.state.pane
+  if target == "" then
+    target = "home"
+  end
+  KeySeerUI.ui:set_pane(target)
 
   KeySeerUI.ui:update()
 end
@@ -131,8 +163,7 @@ function KeySeerUI.create(bufnr)
           self.state.button = button
         end
       end
-      self.state.prev_pane = self.state.pane
-      self.state.pane = k
+      self:set_pane(k)
       self:update()
     end, v["desc"])
   end
@@ -141,25 +172,10 @@ function KeySeerUI.create(bufnr)
 end
 
 ---Update the KeySeer UI
+---Rendering only; pane transitions are handled by set_pane
 ---@private
 function KeySeerUI:update()
   if self.buf and vim.api.nvim_buf_is_valid(self.buf) then
-    if self.state.pane ~= self.state.prev_pane then
-      local pane_available, pane = pcall(require, "keyseer.ui.panes." .. self.state.prev_pane)
-      if pane_available and pane and vim.is_callable(pane.on_exit) then
-        pane.on_exit(self)
-      end
-      pane_available, pane = pcall(require, "keyseer.ui.panes." .. self.state.pane)
-      if pane_available and pane and vim.is_callable(pane.on_enter) then
-        pane.on_enter(self)
-      end
-      -- Track the pane that was entered so that the next update only
-      -- triggers on_exit/on_enter when the pane actually changes.
-      -- Without this, updates that change the pane outside of the pane
-      -- keymaps (like KeySeerUI.show) are not detected as transitions
-      -- and the pane keymaps are never registered.
-      self.state.prev_pane = self.state.pane
-    end
     vim.bo[self.buf].modifiable = true
     self.render:update()
     vim.bo[self.buf].modifiable = false

--- a/lua/keyseer/ui/init.lua
+++ b/lua/keyseer/ui/init.lua
@@ -26,7 +26,7 @@ local default_state = {
   modifiers = {
     ["<Ctrl>"] = false,
     ["<Shift>"] = false,
-    ["<Alt>"] = false,
+    ["<Meta>"] = false,
   },
   bufnr = nil,
 }
@@ -153,6 +153,12 @@ function KeySeerUI:update()
       if pane_available and pane and vim.is_callable(pane.on_enter) then
         pane.on_enter(self)
       end
+      -- Track the pane that was entered so that the next update only
+      -- triggers on_exit/on_enter when the pane actually changes.
+      -- Without this, updates that change the pane outside of the pane
+      -- keymaps (like KeySeerUI.show) are not detected as transitions
+      -- and the pane keymaps are never registered.
+      self.state.prev_pane = self.state.pane
     end
     vim.bo[self.buf].modifiable = true
     self.render:update()

--- a/lua/keyseer/ui/init.lua
+++ b/lua/keyseer/ui/init.lua
@@ -48,16 +48,41 @@ function KeySeerUI.visible()
   return KeySeerUI.ui and KeySeerUI.ui.win and vim.api.nvim_win_is_valid(KeySeerUI.ui.win)
 end
 
-local function get_button_under_cursor(ui)
-  local cursorposition = vim.fn.getcursorcharpos(ui.win)
+---Get the number of buffer rows above the keyboard
+---@return number
+function KeySeerUI:header_offset()
+  -- the keyboard's top border is one row above the first keycap row
+  local border_offset = 1
+  if Config.ui.show_header then
+    -- the header is a blank line, the pane buttons, and a blank line
+    return 3 + border_offset
+  end
+  return border_offset
+end
+
+---Get the button under the cursor
+---@return Button? button The button under the cursor, if any
+function KeySeerUI:get_button_under_cursor()
+  local cursorposition = vim.fn.getcursorcharpos(self.win)
   local row, col = cursorposition[2], cursorposition[3]
-  -- size of the title is statically calculated
-  local row_offset = 4
+  local row_offset = self:header_offset()
   D.log("UI", "Button row, col: " .. row - row_offset .. ", " .. col)
   ---@type Keyboard
-  local keyboard = ui.state.keyboard
-  local button = keyboard:get_keycap_at_position(row - row_offset, col)
-  return button
+  local keyboard = self.state.keyboard
+  return keyboard:get_keycap_at_position(row - row_offset, col)
+end
+
+---Toggle a modifier button
+---This is the only place that writes state.modifiers so that the
+---"Ctrl and Meta are mutually exclusive" invariant always holds
+---@param keycode string The keycode of the modifier button to toggle
+function KeySeerUI:toggle_modifier(keycode)
+  local modifiers = self.state.modifiers
+  modifiers[keycode] = not modifiers[keycode]
+  -- Ctrl and Meta cannot be part of the same keymap; pressing one releases the other
+  if modifiers["<Ctrl>"] and modifiers["<Meta>"] then
+    modifiers[keycode == "<Ctrl>" and "<Meta>" or "<Ctrl>"] = false
+  end
 end
 
 ---Run a lifecycle hook for a pane if the pane defines it
@@ -92,7 +117,7 @@ end
 ---@param bufnr? integer The buffer for keymaps
 function KeySeerUI.show(pane, mode, bufnr)
   bufnr = vim.F.if_nil(bufnr, vim.api.nvim_get_current_buf())
-  KeySeerUI.ui = KeySeerUI.visible() and KeySeerUI.ui or KeySeerUI.create(bufnr)
+  KeySeerUI.ui = KeySeerUI.visible() and KeySeerUI.ui or KeySeerUI.create()
 
   KeySeerUI.ui.state.mode = mode or KeySeerUI.ui.state.mode
   KeySeerUI.ui.state.bufnr = bufnr
@@ -111,12 +136,10 @@ end
 
 ---Create the KeySeer UI
 ---@return KeySeerUI
----@param bufnr? buffer The buffer to retrieve keymaps
 ---@private
-function KeySeerUI.create(bufnr)
+function KeySeerUI.create()
   ---@type KeySeerUI|KeySeerPopup
   local self = setmetatable({}, { __index = setmetatable(KeySeerUI, { __index = Popup }) })
-  bufnr = vim.F.if_nil(bufnr, vim.api.nvim_get_current_buf())
 
   self.state = vim.deepcopy(default_state)
 
@@ -158,7 +181,7 @@ function KeySeerUI.create(bufnr)
   for k, v in pairs(UIConfig.panes) do
     self:on_key(v["key"], function()
       if self.state.pane == "home" then
-        local button = get_button_under_cursor(self)
+        local button = self:get_button_under_cursor()
         if button then
           self.state.button = button
         end

--- a/lua/keyseer/ui/panes/home.lua
+++ b/lua/keyseer/ui/panes/home.lua
@@ -73,8 +73,7 @@ function M.on_enter(ui)
         ui.state.modifiers[button.keycode] = not ui.state.modifiers[button.keycode]
       else
         ui.state.button = button
-        ui.state.prev_pane = ui.state.pane
-        ui.state.pane = "details"
+        ui:set_pane("details")
       end
       ui:update()
     end

--- a/lua/keyseer/ui/panes/home.lua
+++ b/lua/keyseer/ui/panes/home.lua
@@ -12,14 +12,10 @@
 -- ├────────┬──┴───┴──┬┴───┴──┬┴───┴───┴───┴───┴─┬─┴───┴─┬────────┤
 -- │ <CTRL> │ <SUPER> │ <ALT> │      <SPACE>     │ <ALT> │ <CTRL> │
 -- └────────┴─────────┴───────┴──────────────────┴───────┴────────┘
-local D = require("keyseer.util.debug")
 local UIConfig = require("keyseer.ui.config")
 -- Render help
 ---@private
-local M = {
-  count = 0,
-  modifiers = {},
-}
+local M = {}
 
 function M.render(ui)
   local current_keycaps = ui.state.keymaps:get_current_keycaps(ui.state.modifiers)
@@ -45,17 +41,6 @@ function M.render(ui)
   end
 end
 
-local function get_button_under_cursor(ui)
-  local cursorposition = vim.fn.getcursorcharpos(ui.win)
-  local row, col = cursorposition[2], cursorposition[3]
-  -- size of the title is statically calculated
-  local row_offset = 4
-  ---@type Keyboard
-  local keyboard = ui.state.keyboard
-  local button = keyboard:get_keycap_at_position(row - row_offset, col)
-  return button
-end
-
 ---Update keymaps when entering the pane
 function M.on_enter(ui)
   -- go backwards in the key press tree
@@ -67,10 +52,10 @@ function M.on_enter(ui)
 
   -- open details for the keycap under the cursor
   vim.keymap.set("n", UIConfig.keys.details, function()
-    local button = get_button_under_cursor(ui)
+    local button = ui:get_button_under_cursor()
     if button then
       if button.is_modifier then
-        ui.state.modifiers[button.keycode] = not ui.state.modifiers[button.keycode]
+        ui:toggle_modifier(button.keycode)
       else
         ui.state.button = button
         ui:set_pane("details")

--- a/lua/keyseer/ui/text.lua
+++ b/lua/keyseer/ui/text.lua
@@ -1,6 +1,5 @@
 local Utils = require("keyseer.utils")
 local KeySeer = require("keyseer")
-local D = require("keyseer.util.debug")
 
 -- Copied from https://github.com/folke/lazy.nvim/blob/b7043f2983d7aead78ca902f3f2053907081859a/lua/lazy/view/text.lua
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -3,12 +3,9 @@ local helpers = dofile("tests/helpers.lua")
 -- See https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/test.lua for more documentation
 
 local child = helpers.new_child_neovim()
-local eq_global, eq_config, eq_state =
-  helpers.expect.global_equality, helpers.expect.config_equality, helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-  helpers.expect.global_type_equality,
-  helpers.expect.config_type_equality,
-  helpers.expect.state_type_equality
+local eq_config = helpers.expect.config_equality
+local eq_type_global = helpers.expect.global_type_equality
+local eq_type_config = helpers.expect.config_type_equality
 
 local T = MiniTest.new_set({
   hooks = {

--- a/tests/test_display.lua
+++ b/tests/test_display.lua
@@ -3,12 +3,7 @@ local helpers = dofile("tests/helpers.lua")
 -- See https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/test.lua for more documentation
 
 local child = helpers.new_child_neovim()
-local eq_global, eq_config, eq_state =
-  helpers.expect.global_equality, helpers.expect.config_equality, helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-  helpers.expect.global_type_equality,
-  helpers.expect.config_type_equality,
-  helpers.expect.state_type_equality
+local eq_type_global = helpers.expect.global_type_equality
 
 local T = MiniTest.new_set({
   hooks = {

--- a/tests/test_keyboard.lua
+++ b/tests/test_keyboard.lua
@@ -2,12 +2,8 @@
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq_global, eq_config, eq_state =
-  helpers.expect.global_equality, helpers.expect.config_equality, helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-  helpers.expect.global_type_equality,
-  helpers.expect.config_type_equality,
-  helpers.expect.state_type_equality
+local eq_global = helpers.expect.global_equality
+local eq_type_global = helpers.expect.global_type_equality
 
 local T = MiniTest.new_set({
   hooks = {
@@ -133,6 +129,20 @@ end
 
 T["dvorak"]["calculates shift pressed layout"] = function()
   eq_global(child, "dvorak:get_lines(true)", dvorak_shift_pressed_layout)
+end
+
+T["qwerty"]["laying out buttons again does not duplicate them"] = function()
+  child.lua([[keyboard = qwerty:new()]])
+  child.lua([[keyboard:_layout_buttons(false)]])
+  child.lua([[keyboard:_layout_buttons(false)]])
+  eq_global(child, [=[#keyboard._normal_buttons["q"]]=], 1)
+end
+
+T["qwerty"]["looks up buttons from the shifted layout when shift is pressed"] = function()
+  child.lua([[keyboard = qwerty:new()]])
+  child.lua([[keyboard:_layout_buttons(true)]])
+  eq_global(child, [=[#keyboard._shifted_buttons["Q"]]=], 1)
+  eq_global(child, [=[keyboard._locations == keyboard._shifted_buttons]=], true)
 end
 
 return T

--- a/tests/test_keymaps.lua
+++ b/tests/test_keymaps.lua
@@ -173,6 +173,34 @@ T["keymaps"]["gets current keycaps"] = function()
   })
 end
 
+T["keymaps"]["processing keymaps again does not duplicate them"] = function()
+  child.lua([[require("keyseer").config.include_builtin_keymaps = false]])
+  child.lua([[require("keyseer").config.include_global_keymaps = true]])
+  child.lua([[require("keyseer").config.include_buffer_keymaps = false]])
+  child.lua([[vim.keymap.set("n", "gxa", "<cmd>echo 'a'<cr>", { desc = "test keymap" })]])
+  child.lua([[ret = Keymaps:new()]])
+  child.lua([[ret:process_keymaps(nil, "n")]])
+  child.lua([[ret:process_keymaps(nil, "n")]])
+  eq_global(child, [[#ret.root.children["g"].children["x"].children["a"].keymaps]], 1)
+  -- the keycap should not be reported as having multiple keymaps
+  child.lua([[ret:push("g")]])
+  child.lua([[ret:push("x")]])
+  eq_global(child, [=[ret:get_current_keycaps()["a"]]=], "KeySeerKeycapKeymap")
+end
+
+T["keymaps"]["processing keymaps again resets the current node"] = function()
+  child.lua([[require("keyseer").config.include_builtin_keymaps = false]])
+  child.lua([[require("keyseer").config.include_global_keymaps = true]])
+  child.lua([[require("keyseer").config.include_buffer_keymaps = false]])
+  child.lua([[vim.keymap.set("n", "gxa", "<cmd>echo 'a'<cr>", { desc = "test keymap" })]])
+  child.lua([[ret = Keymaps:new()]])
+  child.lua([[ret:process_keymaps(nil, "n")]])
+  child.lua([[ret:push("g")]])
+  child.lua([[ret:process_keymaps(nil, "n")]])
+  eq_global(child, [[ret.current_node == ret.root]], true)
+  eq_global(child, [[#ret.stack]], 0)
+end
+
 T["keymaps"]["matches modifiers"] = function()
   eq_global(child, "Keymaps.matching_keypress({modifiers = {}}, {['<Ctrl>'] = true})", false)
   eq_global(

--- a/tests/test_keymaps.lua
+++ b/tests/test_keymaps.lua
@@ -3,12 +3,8 @@ local helpers = dofile("tests/helpers.lua")
 -- See https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/test.lua for more documentation
 
 local child = helpers.new_child_neovim()
-local eq_global, eq_config, eq_state =
-  helpers.expect.global_equality, helpers.expect.config_equality, helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-  helpers.expect.global_type_equality,
-  helpers.expect.config_type_equality,
-  helpers.expect.state_type_equality
+local eq_global = helpers.expect.global_equality
+local eq_type_global = helpers.expect.global_type_equality
 
 local T = MiniTest.new_set({
   hooks = {
@@ -208,6 +204,34 @@ T["keymaps"]["matches modifiers"] = function()
     "Keymaps.matching_keypress({modifiers = {['<Ctrl>'] = true}}, {['<Ctrl>'] = false})",
     false
   )
+end
+
+T["keymaps"]["matches modifiers truth table"] = function()
+  -- entries are { node modifiers, pressed modifiers, expected match }
+  local cases = {
+    { "{}", "{}", true },
+    { "{['<Shift>']=true}", "{['<Shift>']=true}", true },
+    { "{}", "{['<Shift>']=true}", false },
+    { "{['<Shift>']=true}", "{}", false },
+    { "{['<Ctrl>']=true}", "{['<Ctrl>']=true}", true },
+    { "{['<Ctrl>']=true}", "{}", false },
+    { "{['<Meta>']=true}", "{['<Ctrl>']=true}", false },
+    -- shift is ignored when ctrl is held
+    { "{['<Ctrl>']=true,['<Shift>']=true}", "{['<Ctrl>']=true}", true },
+    { "{['<Ctrl>']=true}", "{['<Ctrl>']=true,['<Shift>']=true}", true },
+    { "{['<Ctrl>']=true,['<Shift>']=true}", "{['<Shift>']=true}", false },
+    { "{['<Ctrl>']=true,['<Meta>']=true}", "{['<Ctrl>']=true,['<Meta>']=true}", true },
+    { "{['<Ctrl>']=true,['<Meta>']=true}", "{['<Ctrl>']=true}", false },
+    { "{['<Meta>']=true}", "{['<Meta>']=true}", true },
+    -- shift is significant when meta is held
+    { "{['<Meta>']=true,['<Shift>']=true}", "{['<Meta>']=true}", false },
+    { "{['<Meta>']=true,['<Shift>']=true}", "{['<Meta>']=true,['<Shift>']=true}", true },
+  }
+  for _, case in ipairs(cases) do
+    local node, pressed, expected = case[1], case[2], case[3]
+    local expression = ("Keymaps.matching_keypress({modifiers = %s}, %s)"):format(node, pressed)
+    eq_global(child, expression, expected)
+  end
 end
 
 T["keypress"] = MiniTest.new_set()

--- a/tests/test_ui.lua
+++ b/tests/test_ui.lua
@@ -51,6 +51,37 @@ T["ui"]["keeps catching key presses after the UI is shown again"] = function()
   eq_global(child, [[#require("keyseer.ui").ui.state.keymaps.stack]], 0)
 end
 
+T["ui"]["finds the button under the cursor"] = function()
+  child.cmd("KeySeer")
+  child.lua([[vim.fn.search("\\<q\\>")]])
+  child.type_keys("<CR>")
+  eq_global(child, [[require("keyseer.ui").ui.state.pane]], "details")
+  eq_global(child, [[require("keyseer.ui").ui.state.button.keycode]], "q")
+end
+
+T["ui"]["finds the button under the cursor without a header"] = function()
+  child.lua([[require("keyseer").setup({ ui = { show_header = false } })]])
+  child.cmd("KeySeer")
+  child.lua([[vim.fn.search("\\<q\\>")]])
+  child.type_keys("<CR>")
+  eq_global(child, [[require("keyseer.ui").ui.state.pane]], "details")
+  eq_global(child, [[require("keyseer.ui").ui.state.button.keycode]], "q")
+end
+
+T["ui"]["toggles modifiers through a single writer"] = function()
+  child.cmd("KeySeer")
+  child.lua([[ui = require("keyseer.ui").ui]])
+  child.lua([[ui:toggle_modifier("<Ctrl>")]])
+  eq_global(child, [=[ui.state.modifiers["<Ctrl>"]]=], true)
+  -- Ctrl and Meta are mutually exclusive: pressing Meta releases Ctrl
+  child.lua([[ui:toggle_modifier("<Meta>")]])
+  eq_global(child, [=[ui.state.modifiers["<Meta>"]]=], true)
+  eq_global(child, [=[ui.state.modifiers["<Ctrl>"]]=], false)
+  -- toggling again releases the modifier
+  child.lua([[ui:toggle_modifier("<Meta>")]])
+  eq_global(child, [=[ui.state.modifiers["<Meta>"]]=], false)
+end
+
 T["ui"]["does not duplicate keymaps when the UI is shown again"] = function()
   child.cmd("KeySeer")
   child.cmd("KeySeer")

--- a/tests/test_ui.lua
+++ b/tests/test_ui.lua
@@ -1,0 +1,64 @@
+local helpers = dofile("tests/helpers.lua")
+
+-- See https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/test.lua for more documentation
+
+local child = helpers.new_child_neovim()
+local eq_global = helpers.expect.global_equality
+
+local T = MiniTest.new_set({
+  hooks = {
+    -- This will be executed before every (even nested) case
+    pre_case = function()
+      -- Restart child process with custom 'init.lua' script
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      -- the child is started with --noplugin, so source the plugin to get the command
+      child.cmd("runtime! plugin/keyseer.lua")
+      -- add a nested keymap so the keymap tree has a prefix to descend into
+      child.lua([[vim.keymap.set("n", "gxa", "<cmd>echo 'a'<cr>", { desc = "test keymap" })]])
+    end,
+    -- This will be executed one after all tests from this set are finished
+    post_once = child.stop,
+  },
+})
+
+T["ui"] = MiniTest.new_set()
+
+T["ui"]["catches key presses to navigate the keymap tree"] = function()
+  child.cmd("KeySeer")
+  -- the home pane registers buffer-local keymaps to catch key presses
+  eq_global(child, [[vim.fn.maparg("<BS>", "n", false, true).buffer == 1]], true)
+  eq_global(child, [[vim.fn.maparg("<CR>", "n", false, true).buffer == 1]], true)
+  -- descend into the 'g' prefix
+  child.type_keys("g", "g")
+  eq_global(child, [[#require("keyseer.ui").ui.state.keymaps.stack]], 1)
+  -- go back up
+  child.type_keys("<BS>")
+  eq_global(child, [[#require("keyseer.ui").ui.state.keymaps.stack]], 0)
+end
+
+T["ui"]["keeps catching key presses after the UI is shown again"] = function()
+  child.cmd("KeySeer")
+  -- switch to the help pane, then show the UI again while it is open
+  child.type_keys("?")
+  child.cmd("KeySeer")
+  -- the key press keymaps must be registered again
+  eq_global(child, [[vim.fn.maparg("<BS>", "n", false, true).buffer == 1]], true)
+  eq_global(child, [[vim.fn.maparg("<CR>", "n", false, true).buffer == 1]], true)
+  -- descending and going back must still work
+  child.type_keys("g", "g")
+  eq_global(child, [[#require("keyseer.ui").ui.state.keymaps.stack]], 1)
+  child.type_keys("<BS>")
+  eq_global(child, [[#require("keyseer.ui").ui.state.keymaps.stack]], 0)
+end
+
+T["ui"]["does not duplicate keymaps when the UI is shown again"] = function()
+  child.cmd("KeySeer")
+  child.cmd("KeySeer")
+  eq_global(
+    child,
+    [[#require("keyseer.ui").ui.state.keymaps.root.children["g"].children["x"].children["a"].keymaps]],
+    1
+  )
+end
+
+return T

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -3,12 +3,8 @@ local helpers = dofile("tests/helpers.lua")
 -- See https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/test.lua for more documentation
 
 local child = helpers.new_child_neovim()
-local eq_global, eq_config, eq_state =
-  helpers.expect.global_equality, helpers.expect.config_equality, helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-  helpers.expect.global_type_equality,
-  helpers.expect.config_type_equality,
-  helpers.expect.state_type_equality
+local eq_global = helpers.expect.global_equality
+local eq_type_global = helpers.expect.global_type_equality
 
 local T = MiniTest.new_set({
   hooks = {


### PR DESCRIPTION
## Summary

Fixes the state tracking bugs that broke catching and showing key presses, then refactors the surrounding state handling so the same class of bug can't come back.

### Bug fixes

- **Key catching died after re-running `:KeySeer` while the UI was open.** `update()` detected pane transitions by comparing `pane` with `prev_pane`, but never recorded the pane it entered, and `show()` changed the pane without going through the key handlers that maintained `prev_pane`. The home pane's `on_enter` was skipped, so the `<bs>`/`<cr>` keymaps were never re-registered and navigation went dead.
- **Re-running `:KeySeer` duplicated every keymap.** `process_keymaps()` appended into the existing tree, so keys with one mapping were highlighted as having multiple and the details pane listed duplicates. The tree is now rebuilt from scratch on each call.
- **`<cr>` resolved the wrong button when `ui.show_header = false`.** The cursor lookup hardcoded a 4-row header offset; the offset is now derived from the config.
- **`Keyboard:_layout_buttons` reset the wrong lookup table** (laying out the unshifted keyboard cleared the *shifted* table), so every render accumulated duplicate buttons and shifted lookups searched an empty table.

### Refactors

- All pane changes flow through a single `KeySeerUI:set_pane()` writer that runs `on_exit`/`on_enter` exactly once per change; `update()` is rendering-only.
- Modifier toggling flows through `KeySeerUI:toggle_modifier()`, which enforces Ctrl/Meta mutual exclusion at mutation time (replacing the render-time warning).
- `modifiers_match` is rewritten as a comparison of canonical modifier strings, making the "shift is ignored while ctrl is held" rule explicit; the previous truth table is pinned by tests that pass against both implementations.
- Removed dead state, duplicate helpers, and unused locals; the repeated modifier-defaulting tables are centralized.

### Tests & tooling

- New `tests/test_ui.lua` exercises the real `:KeySeer` flow: navigation, re-show, button-under-cursor (with and without header), and modifier toggling. All regression tests were verified to fail on the unfixed code.
- 42 test cases pass on stable (v0.12.3) and nightly (v0.13.0-dev).
- Added luacheck (`.luacheckrc`, `make luacheck`, CI lint step); the tree lints clean.
- CI test matrix now covers maintained Neovim versions only (`stable`, `nightly`), dropping v0.7.2/v0.8.3/v0.9.1.

https://claude.ai/code/session_012MueXmf5s2iyRWBYBPPvzn

---
_Generated by [Claude Code](https://claude.ai/code/session_012MueXmf5s2iyRWBYBPPvzn)_